### PR TITLE
A small fix in the description of the format for the election results

### DIFF
--- a/election-results/README.md
+++ b/election-results/README.md
@@ -9,7 +9,7 @@ The fields in the file will be separated by commas but each row will vary in len
 A result will consist of:
 
 1. A constituency
-2. A repeating set of pairs with the party code and the votes cast
+2. A repeating set of pairs with the votes cast and the party code
 
 So for example:
 


### PR DESCRIPTION
I fixed a small inconsistency in the description of the election results, as in the example output votes come before the party code